### PR TITLE
system.sh: Remove log file written to SD on boot containing the WiFi password

### DIFF
--- a/src/static/static/home/yi-hack/script/system.sh
+++ b/src/static/static/home/yi-hack/script/system.sh
@@ -248,7 +248,8 @@ if [[ $FREE_SPACE != "0" ]] ; then
     $YI_HACK_PREFIX/usr/sbin/crond -c /var/spool/cron/crontabs/
 fi
 
-# Remove log file written to SD on boot containing the WiFi password
+# Remove log files written to SD on boot containing the WiFi password
+rm -f "/tmp/sd/log/log_first_login.tar.gz"
 rm -f "/tmp/sd/log/log_wifi_connected.tar.gz"
 
 if [ -f "/tmp/sd/yi-hack/startup.sh" ]; then

--- a/src/static/static/home/yi-hack/script/system.sh
+++ b/src/static/static/home/yi-hack/script/system.sh
@@ -248,6 +248,9 @@ if [[ $FREE_SPACE != "0" ]] ; then
     $YI_HACK_PREFIX/usr/sbin/crond -c /var/spool/cron/crontabs/
 fi
 
+# Remove log file written to SD on boot containing the WiFi password
+rm -f "/tmp/sd/log/log_wifi_connected.tar.gz"
+
 if [ -f "/tmp/sd/yi-hack/startup.sh" ]; then
     /tmp/sd/yi-hack/startup.sh
 fi


### PR DESCRIPTION
Purpose:
- Yi firmware writes a log to the SD card (if present) on boot which contains sensitive information tar'ed up to one file. This file should be removed automatically in order to prevent leaking the WiFi password in case someone takes off the camera from the wall and takes out the sdcard.

This is unrelated to Yi-Hack, but very useful for security matters and should be considered to go in as a workaround.

Testing:
- Verified working on my Yi Home 1080p v3 Camera (BFUSY31) with YiHack-allwinner 0.1.6
- I've placed the workaround into /tmp/sd/yi-hack/startup.sh for testing

```
#!/bin/sh
#
# Setup env.
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/lib:/home/yi-hack/lib:/tmp/sd/yi-hack/lib
export PATH=$PATH:/home/base/tools:/home/yi-hack/bin:/home/yi-hack/sbin:/home/yi-hack/usr/bin:/home/yi-hack/usr/sbin:/tmp/sd/yi-hack/bin:/tmp/sd/yi-hack/sbin
#
rm -f "/tmp/sd/log/log_wifi_connected.tar.gz"
#
exit 0

```