### PR TITLE
Remove log files written to SD on boot containing the WiFi password (2) (fixes #91)

### DIFF
--- a/src/static/static/home/yi-hack/script/system.sh
+++ b/src/static/static/home/yi-hack/script/system.sh
@@ -249,6 +249,8 @@ fi
 
 # Remove log files written to SD on boot containing the WiFi password
 rm -f "/tmp/sd/log/log_first_login.tar.gz"
+rm -f "/tmp/sd/log/log_login.tar.gz"
+rm -f "/tmp/sd/log/log_p2p_clr.tar.gz"
 rm -f "/tmp/sd/log/log_wifi_connected.tar.gz"
 
 if [[ $(get_config FTP_UPLOAD) == "yes" ]] ; then


### PR DESCRIPTION
Follow-up to PR:
https://github.com/roleoroleo/yi-hack-Allwinner/pull/57

Fixes issue: #91 