### PR TITLE
Fix flag Switch on/off the camera in version 0.1.9

### DIFF
--- a/src/www/httpd/cgi-bin/camera_settings.sh
+++ b/src/www/httpd/cgi-bin/camera_settings.sh
@@ -5,7 +5,7 @@ CONF_FILE="$YI_HACK_PREFIX/etc/camera.conf"
 
 CONF_LAST="CONF_LAST"
 
-for I in 1 2 3 4 5 6 7
+for I in 1 2 3 4 5 6 7 8
 do
     CONF="$(echo $QUERY_STRING | cut -d'&' -f$I | cut -d'=' -f1)"
     VAL="$(echo $QUERY_STRING | cut -d'&' -f$I | cut -d'=' -f2)"


### PR DESCRIPTION
This bug-fix resolve a small porblem in 0.1.9.

The flag Switch on/off not work in 0.1.9.