### PR TITLE
Fix for mapping the root path for .ssh/authorized_keys ( #133 )

### DIFF
--- a/src/static/static/home/yi-hack/script/system.sh
+++ b/src/static/static/home/yi-hack/script/system.sh
@@ -86,6 +86,7 @@ if [[ x$(get_config SSH_PASSWORD) != "x" ]] ; then
     PASSWORD_MD5="$(echo "${SSH_PASSWORD}" | mkpasswd --method=MD5 --stdin)"
     cp -f "/etc/passwd" "/home/yi-hack/etc/passwd"
     sed -i 's|^root::|root:'${PASSWORD_MD5}':|g' "/home/yi-hack/etc/passwd"
+    sed -i 's|/root|/home/yi-hack-v4|g' "/home/yi-hack/etc/passwd"
     mount --bind "/home/yi-hack/etc/passwd" "/etc/passwd"
     cp -f "/etc/shadow" "/home/yi-hack/etc/shadow"
     sed -i 's|^root::|root:'${PASSWORD_MD5}':|g' "/home/yi-hack/etc/shadow"

--- a/src/static/static/home/yi-hack/script/system.sh
+++ b/src/static/static/home/yi-hack/script/system.sh
@@ -86,7 +86,7 @@ if [[ x$(get_config SSH_PASSWORD) != "x" ]] ; then
     PASSWORD_MD5="$(echo "${SSH_PASSWORD}" | mkpasswd --method=MD5 --stdin)"
     cp -f "/etc/passwd" "/home/yi-hack/etc/passwd"
     sed -i 's|^root::|root:'${PASSWORD_MD5}':|g' "/home/yi-hack/etc/passwd"
-    sed -i 's|/root|/home/yi-hack-v4|g' "/home/yi-hack/etc/passwd"
+    sed -i 's|/root|/home/yi-hack|g' "/home/yi-hack/etc/passwd"
     mount --bind "/home/yi-hack/etc/passwd" "/etc/passwd"
     cp -f "/etc/shadow" "/home/yi-hack/etc/shadow"
     sed -i 's|^root::|root:'${PASSWORD_MD5}':|g' "/home/yi-hack/etc/shadow"


### PR DESCRIPTION
This modify change the root path from `/root` to `/home/yi-hack-v4/` and allow to use the `.ssh/authorized_keys` as descripted in the documentation [wiki/SSH:-login-with-keys ](https://github.com/roleoroleo/yi-hack-Allwinner/wiki/SSH:-login-with-keys)

( Fix #133 )