### PR TITLE
Fix Mqtt will message on web Reboot

### DIFF
--- a/src/www/httpd/cgi-bin/reboot.sh
+++ b/src/www/httpd/cgi-bin/reboot.sh
@@ -9,5 +9,6 @@ printf "}\n"
 sync
 sync
 sync
+killall -q mqttv4
 sleep 1
 reboot


### PR DESCRIPTION
I see a Will message on MQTT by the version 0.2.0.

When the reboot is called by web interface the will massage is not displayed on mqtt.

This modify allow to show will message on web reboot