### PR TITLE
ftppush.sh: Less logspam and cooldown if FTP server or network encounters interrupted transfers (fixes #313)

### DIFF
--- a/src/static/static/home/yi-hack/script/ftppush.sh
+++ b/src/static/static/home/yi-hack/script/ftppush.sh
@@ -70,8 +70,8 @@ checkFiles ()
 		LAST_FILE_SENT_REMPART=${LAST_FILE_SENT:5:2}${LAST_FILE_SENT:8:2}${LAST_FILE_SENT:11:2}${LAST_FILE_SENT:14:2}
 		if [ ${FILE_YEAR} -gt ${LAST_FILE_SENT_YEAR} ] || ( [ ${FILE_YEAR} -eq ${LAST_FILE_SENT_YEAR} ] && [ ${FILE_REMPART} -gt ${LAST_FILE_SENT_REMPART} ] ); then
 			if ( ! uploadToFtp -- "${file}" ); then
-				logAdd "[ERROR] checkFiles: uploadToFtp FAILED - [${file}]."
-				continue
+				logAdd "[ERROR] checkFiles: uploadToFtp FAILED - [${file}]. Retrying in ${SLEEP_CYCLE_SECONDS} s."
+				return 0
 			fi
 			logAdd "[INFO] checkFiles: uploadToFtp SUCCEEDED - [${file}]."
 			LAST_FILE_SENT=${FILE_DATE}


### PR DESCRIPTION
Purpose:
- ftppush.sh: Less logspam and cooldown if FTP server or network encounters interrupted transfers

e.g. in low disk space scenarios on the FTP server if a "ring buffer" tmpfs partition is used to further process video mp4 files and sort those out that contain really useful stuff (instead of swinging plants in the garden when the wind blows).

Testing:
I've tested this on my yicam and it works fine to resume transfers if the "disk full" has been solved on the FTP side meanwhilst after 45 seconds of cooldown time.
